### PR TITLE
feat(tinyint): Add support for treating specified tinyint columns as bools

### DIFF
--- a/internal/argtype.go
+++ b/internal/argtype.go
@@ -43,6 +43,9 @@ type ArgType struct {
 	// Uint32Type is the type to assign those discovered as uint32.
 	Uint32Type string `arg:"--uint32-type,-u,help:Go type to assign to unsigned integers"`
 
+	// FieldsTinyintAsBool is the columns to treat as bools.
+	FieldsTinyintAsBool []string `arg:"--fields-tinyint-as-bool,help:columns to treat as bool"`
+
 	// IgnoreFields allows the user to specify field names which should not be
 	// handled by xo in the generated code.
 	IgnoreFields []string `arg:"--ignore-fields,help:fields to exclude from the generated Go code types"`

--- a/internal/loader.go
+++ b/internal/loader.go
@@ -543,7 +543,6 @@ func (tl TypeLoader) LoadColumns(args *ArgType, typeTpl *Type) error {
 	// process columns
 	for _, c := range columnList {
 		ignore := false
-
 		for _, ignoreField := range args.IgnoreFields {
 			switch v := strings.Split(ignoreField, "."); len(v) {
 			case 2:
@@ -562,9 +561,25 @@ func (tl TypeLoader) LoadColumns(args *ArgType, typeTpl *Type) error {
 				}
 			}
 		}
-
 		if ignore {
 			continue
+		}
+
+		if strings.HasPrefix(strings.ToLower(c.DataType), "tinyint") {
+			for _, field := range args.FieldsTinyintAsBool {
+				switch v := strings.Split(field, "."); len(v) {
+				case 2:
+					if strings.EqualFold(v[0], typeTpl.Table.TableName) && strings.EqualFold(v[1], c.ColumnName) {
+						c.DataType = "tinyint(1)"
+						break
+					}
+				case 1:
+					if strings.EqualFold(v[0], c.ColumnName) {
+						c.DataType = "tinyint(1)"
+						break
+					}
+				}
+			}
 		}
 
 		// set col info


### PR DESCRIPTION
It wasn't restored for tinyint unsigned in mysql 8.0.19.
So add `--fields-tinyint-as-bool` option for treating specified tinyint columns as bool.

ref. https://bugs.mysql.com/bug.php?id=98250